### PR TITLE
When day start with `0`is interpreted as octal by bash

### DIFF
--- a/3048m.sh
+++ b/3048m.sh
@@ -136,4 +136,3 @@ else
 
     cmd_"$command" "${@}" || usage
 fi
-

--- a/3048m.sh
+++ b/3048m.sh
@@ -136,3 +136,4 @@ else
 
     cmd_"$command" "${@}" || usage
 fi
+

--- a/3048m.sh
+++ b/3048m.sh
@@ -44,9 +44,9 @@ function authenticate {
 function set_dates {
     month_shift=$1
     [ -n "$month_shift" ] || month_shift=0
-
-    FIRST_DAY=$(date -d "-$(($(date +%d)-1)) days -$month_shift month" +"%Y-%m-%d")
-    LAST_DAY=$(date -d "-$(date +%d) days +1 month -$month_shift month" +"%Y-%m-%d")
+    DATE=$(date +%d)
+    FIRST_DAY=$(date -d "-$((${DATE#0}-1)) days -$month_shift month" +"%Y-%m-%d")
+    LAST_DAY=$(date -d "-${DATE#0} days +1 month -$month_shift month" +"%Y-%m-%d")
 }
 
 function cmd_entries { # entries [<MONTH_BEHIND>]


### PR DESCRIPTION
When I try to get the report since the new year I have these two errors:
- /home/marco/bin/3048m.sh: line 49: 09: value too great for base (error token is "09")
- /home/marco/bin/3048m.sh: line 49: 09: value too great for base (error token is "09")

The reason is this one: https://stackoverflow.com/questions/12821715/convert-string-into-integer-in-bash-script/12821845#12821845

In this PR a possible solution. 